### PR TITLE
modified .gitignore to exclude IntelliJ IDE project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.exe 
+*.iml
+/.idea


### PR DESCRIPTION
IntelliJ was the only IDE that I could find with a golang syntax highlighting addon
